### PR TITLE
[FIX] monorepo component name collision using relative path prefix

### DIFF
--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/Richonn/shieldci/internal/config"
@@ -154,7 +155,11 @@ func GenerateMonorepo(components []detect.Component, cfg *config.Config) ([]Gene
 		if err != nil {
 			return nil, err
 		}
-		name := filepath.Base(c.Path)
+		rel, err := filepath.Rel(cfg.WorkspaceDir, c.Path)
+		if err != nil {
+			rel = filepath.Base(c.Path)
+		}
+		name := strings.ReplaceAll(rel, string(filepath.Separator), "-")
 		for i := range generated {
 			generated[i].Path = name + "-" + generated[i].Path
 		}

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Richonn/shieldci/internal/config"
 	"github.com/Richonn/shieldci/internal/detect"
 )
 
@@ -121,6 +122,59 @@ func TestPRBodyWithDocker(t *testing.T) {
 	body := PRBody(s, files)
 	if !strings.Contains(body, "Docker") {
 		t.Error("expected Docker in PR body")
+	}
+}
+
+func TestGenerateMonorepoNoDuplicateNames(t *testing.T) {
+	components := []detect.Component{
+		{Path: "/workspace/services/api", Language: "go", BuildTool: "go"},
+		{Path: "/workspace/tools/api", Language: "node", BuildTool: "npm"},
+		{Path: "/workspace/backend/services/api", Language: "go", BuildTool: "go"},
+		{Path: "/workspace/frontend/services/api", Language: "node", BuildTool: "npm"},
+	}
+	cfg := &config.Config{
+		WorkspaceDir:   "/workspace",
+		EnableTrivy:    true,
+		EnableGitleaks: true,
+		EnableSAST:     true,
+		SASTTool:       "codeql",
+	}
+
+	files, err := GenerateMonorepo(components, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seen := make(map[string]bool)
+	for _, f := range files {
+		if seen[f.Path] {
+			t.Errorf("duplicate file path: %s", f.Path)
+		}
+		seen[f.Path] = true
+	}
+}
+
+func TestGenerateMonorepoFilePrefix(t *testing.T) {
+	components := []detect.Component{
+		{Path: "/workspace/services/api", Language: "go", BuildTool: "go"},
+	}
+	cfg := &config.Config{
+		WorkspaceDir:   "/workspace",
+		EnableTrivy:    true,
+		EnableGitleaks: true,
+		EnableSAST:     true,
+		SASTTool:       "codeql",
+	}
+
+	files, err := GenerateMonorepo(components, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, f := range files {
+		if !strings.HasPrefix(f.Path, "services-api-") {
+			t.Errorf("expected prefix 'services-api-', got: %s", f.Path)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

When two components share the same directory name in different parts of a monorepo (e.g. `services/api` and `tools/api`), `filepath.Base()` returns `api` for both — causing the second component's generated workflows to silently overwrite the first.

## Root cause

`generate.go` used `filepath.Base(c.Path)` to prefix generated filenames, keeping only the last path segment.

## Fix

Replace `filepath.Base` with `filepath.Rel` from the workspace root, then sanitize the separator to `-`. This produces unique, fully-qualified prefixes:

- `services/api` → `services-api-ci.yml`
- `tools/api` → `tools-api-ci.yml`
- `backend/services/api` → `backend-services-api-ci.yml`
- `frontend/services/api` → `frontend-services-api-ci.yml`

## Tests

Added two tests in `generate_test.go`:
- `TestGenerateMonorepoNoDuplicateNames` — asserts no duplicate file paths across components with identical names at different depths
- `TestGenerateMonorepoFilePrefix` — asserts the generated prefix uses the full relative path
